### PR TITLE
Fix behavior after copying a color

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,8 @@
 	clipboard.on('success', function(e) {
 		e.trigger.classList.add("copied");
 		setTimeout(function(){
-			e.trigger.blur();
+			$("#tints-and-shades").attr("tabindex", "0");
+			$("#tints-and-shades").focus();
 		}, 250);
 		setTimeout(function(){
 			e.trigger.classList.remove("copied");


### PR DESCRIPTION
I updated the changes made for #11 so that focus returns to the table when a color is copied. Currently, the focus is just removed and hitting tab brings the user back up to the top of the page (because of f83946c). This pull request matches the behavior to what was introduced in #18.