### PR TITLE
Closes issue #40

### DIFF
--- a/scripts/tints-and-shades.js
+++ b/scripts/tints-and-shades.js
@@ -220,7 +220,7 @@ $(document).ready(function() {
   // connect the form submit button to all of the guts
   $("#color-entry-form").submit(createTintsAndShades);
 
-  $("#copy-with-hashtag").on("click", function(e) {
+  $("#copy-with-hashtag").on("change", function(e) {
     settings.copyWithHashtag = e.target.checked;
     // this will just fail-fast if the tables haven't been generated yet
     updateClipboardData();


### PR DESCRIPTION
This pull request tries to fix issue #40, where the switch doesn't respond to the enter key as expected leading to accessibility issues. To fix this, the "click" event was replaced with the "change" event for the #copy-with-hashtag element to respond to both mouse clicks and changes triggered by the enter key.


![Tints and Shades Demo](https://github.com/edelstone/tints-and-shades/assets/75938195/3166e83d-5685-405d-aa83-470998c33db1)
