### PR TITLE
Restore Astro migration from pre-merge branch

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,24 @@
-# API release flow
+# npm package release flow
 
-**Applies only when releasing the npm package.** If `packages/tints-and-shades` isn’t modified, just commit and push to `main`.
+This document applies only when releasing the npm package at `packages/tints-and-shades`.
+
+## When a release is required
+
+Publish a new npm version when the changes should ship to npm consumers. This usually means changes to:
+
+- `packages/tints-and-shades/src/*`
+- `packages/tints-and-shades/package.json`
+- anything else that changes the built output in `packages/tints-and-shades/dist`
+
+You usually do not need a release for package-internal changes that do not affect what npm consumers receive, such as:
+
+- `packages/tints-and-shades/test/*`
+- tooling or config changes
+- README changes, unless you want the npm package documentation updated
+
+If no npm release is needed, just commit and push to `main`.
+
+## Release steps
 
 1. Commit code changes.
 
@@ -31,7 +49,7 @@
     npm version patch   # or minor / major
     ```
 
-    _The only files changed should be `package-lock.json` and `packages/tints-and-shades/package.json`._
+    _At this step, the only files changed should be `package-lock.json` and `packages/tints-and-shades/package.json`._
 
 5. Publish to npm.
 

--- a/src/components/BaseLayout.astro
+++ b/src/components/BaseLayout.astro
@@ -1,9 +1,6 @@
 ---
 import "../styles/styles.scss";
 import "@melloware/coloris/dist/coloris.css";
-import appScriptUrl from "../scripts/app.js?url";
-import docsScriptUrl from "../scripts/heading-anchors.js?url";
-import themeScriptUrl from "../scripts/theme-toggle.js?url";
 import Footer from "./Footer.astro";
 import Head from "./Head.astro";
 import Header from "./Header.astro";
@@ -35,8 +32,10 @@ const is404Page = pathname === "/404.html";
     </main>
     <Footer main={main} />
     <IconTemplates />
-    {main && <script is:inline type="module" src={appScriptUrl} />}
-    {docs && <script is:inline type="module" src={docsScriptUrl} />}
-    <script is:inline type="module" src={themeScriptUrl}></script>
+    {main && <script>import "../scripts/app.js";</script>}
+    {docs && <script>import "../scripts/heading-anchors.js";</script>}
+    <script>
+      import "../scripts/theme-toggle.js";
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Restores the Astro migration from `fd51fb0`, the pre-merge `astro-work` state.

This avoids the broken merge path that produced the current `main` regression, where only part of the Astro migration was reintroduced. The branch here is the last known coherent Astro state before `astro-work` was merged with `main` locally.